### PR TITLE
Kilianus < Klinianus

### DIFF
--- a/Manuscripts/Den Arnamagnæanske Samling/AM/AM04/da/AM04-0732-b-da.xml
+++ b/Manuscripts/Den Arnamagnæanske Samling/AM/AM04/da/AM04-0732-b-da.xml
@@ -126,7 +126,7 @@
                             <bibl>Kålund: <ref target="STUAGNL45">Alfræði Íslenzk</ref><biblScope unit="volume">III</biblScope>
                                 <biblScope unit="page">64-66</biblScope></bibl>
                             <msItem n="9.1" class="dyrl">
-                                <title type="supplied">Notits om den hellige Klinianus
+                                <title type="supplied">Notits om den hellige Kilianus
                                     martyrium</title>
                                 <textLang mainLang="non">Norrønt/Islandsk</textLang>
                             </msItem>


### PR DESCRIPTION
Meg Cormack writes:

I was recently looking at the entry for AM 732 b 4to, which reads in part: 

9.1
Notits om den hellige Klinianus martyrium
Tungumál textans
norræna
Efnisorð
Dýrlingar

There is, in fact, no such saint as Klinianus.  As you will see from the attachments, the reference is to St. Kilianus of Wurzburg in Franconia, in english the text could be 'Note about the martyrdom of St. Kilian'  I was told that you were the one able to correct the name of the saint (the name of the place is also mangled, but you don´t really need that. St. Kilian was in fact Irish, but became a saint in Franconia, just in case you are interested.) Thanks in advance and Best wishes,
Margaret Cormack